### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: SonarQube
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/dci-marc/sakila-rest/security/code-scanning/3](https://github.com/dci-marc/sakila-rest/security/code-scanning/3)

To fix the problem, you should add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. In this case, the workflow only needs to read repository contents (for checkout and analysis), so setting `contents: read` is sufficient. You can add the `permissions` block at the root level of the workflow (before `jobs:`) to apply it to all jobs, or at the job level if you want to restrict permissions for a specific job. The best practice is to add it at the root level unless you have jobs with different permission requirements. Edit the `.github/workflows/build.yml` file and insert the following block after the `name:` and before `on:`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
